### PR TITLE
Fix nullable parameter handling and code formatting

### DIFF
--- a/bin/zero-to-prod-package-helper
+++ b/bin/zero-to-prod-package-helper
@@ -7,16 +7,16 @@
  * Publishes the README.md file to the user's documentation directory.
  */
 
-require getcwd() . '/vendor/autoload.php';
+require getcwd().'/vendor/autoload.php';
 
 use Zerotoprod\PackageHelper\PackageHelper;
 
-$target_path = getcwd() . '/docs/zero-to-prod/package-helper/';
+$target_path = getcwd().'/docs/zero-to-prod/package-helper/';
 if (isset($argv[1])) {
-    $target_path = rtrim($argv[1], '/') . '/';
+    $target_path = rtrim($argv[1], '/').'/';
 }
 
-$source_file = __DIR__ . '/../README.md';
+$source_file = getcwd().'/README.md';
 
 if (!file_exists($source_file)) {
     fwrite(STDERR, "Error: Not found $source_file\n");
@@ -25,10 +25,10 @@ if (!file_exists($source_file)) {
 
 // Use PackageHelper to perform the copy (will create the target directory as needed)
 try {
-    PackageHelper::copy($source_file, $target_path);
+    PackageHelper::copy($source_file, $target_path, null);
     exit(0);
 } catch (RuntimeException $e) {
-    fwrite(STDERR, "Error: " . $e->getMessage() . "\n");
+    fwrite(STDERR, "Error: ".$e->getMessage()."\n");
     exit(1);
 }
 

--- a/src/PackageHelper.php
+++ b/src/PackageHelper.php
@@ -41,9 +41,9 @@ class PackageHelper
      * @throws RuntimeException If a directory cannot be created or a file cannot be written
      * @link https://github.com/zero-to-prod/package-helper
      */
-    public static function publish(string $from, string $to, string $project_namespace, Closure $CopyEvent = null): void
+    public static function publish(string $from, string $to, string $project_namespace, ?Closure $CopyEvent): void
     {
-        (new self())->copyFiles($from, $to, $project_namespace, $CopyEvent);
+        (new self())->copyFiles($from, $to, $project_namespace, $CopyEvent ?? null);
     }
 
     /**
@@ -74,7 +74,7 @@ class PackageHelper
      * @throws RuntimeException If the source file is missing or target directory cannot be created/written
      * @link https://github.com/zero-to-prod/package-helper
      */
-    public static function copy(string $source_file, ?string $target_path = null, Closure $CopyEvent = null): string
+    public static function copy(string $source_file, ?string $target_path = null, ?Closure $CopyEvent = null): string
     {
         $target_path = rtrim($target_path ?: getcwd(), '/').'/';
 

--- a/src/PackageHelper.php
+++ b/src/PackageHelper.php
@@ -41,7 +41,7 @@ class PackageHelper
      * @throws RuntimeException If a directory cannot be created or a file cannot be written
      * @link https://github.com/zero-to-prod/package-helper
      */
-    public static function publish(string $from, string $to, string $project_namespace, ?Closure $CopyEvent): void
+    public static function publish(string $from, string $to, string $project_namespace, ?Closure $CopyEvent = null): void
     {
         (new self())->copyFiles($from, $to, $project_namespace, $CopyEvent ?? null);
     }


### PR DESCRIPTION
## Description

  - Make `CopyEvent` parameters nullable in both `publish()` and `copy()` methods
  - Update concatenation spacing to use consistent PHP style (no spaces around .)
  - Fix source file path in publishing script to use relative path

Changes Made

  - `src/PackageHelper.php:` Added nullable type hints (``?Closure`) for `CopyEvent` parameters in `publish()` and `copy()` methods
  - `bin/zero-to-prod-package-helper`: Updated string concatenation to remove spaces around . operator and fixed source file path reference

Technical Details

This change improves the API by making the callback parameter truly optional with proper nullable type hints, while also standardizing code formatting across the
  codebase.